### PR TITLE
Add DiabloBlazor to Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Note: the Blazor Visual Studio extension is no longer required since .NET Core 3
 * [BlazorDice](https://github.com/shahedc/BlazorDemos/tree/master/BlazorDice) - Roll the dice.
 * [BlazorPong](https://github.com/MACEL94/BlazorPong) - Pong in Blazor server side using SignalR Core. [Demo](https://blazorpong-dev-as.azurewebsites.net).
 * [BlazorTictactoe](https://github.com/kodebot/BlazorTicTacToe) - Tic-tac-toe in Blazor WebAssembly. [Demo](https://tic-tac-toe.kodebot.com/).
+* [DiabloBlazor](https://github.com/n-stefan/diabloblazor) - Blazor port of DiabloWeb, making it a double WebAssembly app: a WebAssembly (C#) SPA hosting a WebAssembly (C++) game. [Demo](https://n-stefan.github.io/diabloblazor).
 ### Machine Learning
 * [Scalable sentiment analysis](https://github.com/dotnet/machinelearning-samples/tree/master/samples/csharp/end-to-end-apps/ScalableSentimentAnalysisBlazorWebApp) - ![GitHub stars](https://img.shields.io/github/stars/dotnet/machinelearning-samples?style=flat-square&cacheSeconds=604800) A sample ables to make sentiment analysis prediction/detection of what the user is writing in a very UI interactive app (Blazor based) in the client side and running an ML.NET model (Sentiment analysis based on binary-classification) in the server side.
 ### ToDos


### PR DESCRIPTION
DiabloBlazor is a Blazor port of [DiabloWeb](https://github.com/d07RiV/diabloweb), which makes it a double WebAssembly app: a WebAssembly (C#) SPA hosting a WebAssembly (C++) game.
It swaps out React used in DiabloWeb for Blazor and also leverages TypeScript (except for the JavaScript glue code generated by Emscripten).