### PR TITLE
Add "Blazor Wake-on-LAN" in "Sample Projects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ Note: the Blazor Visual Studio extension is no longer required since .NET Core 3
 * [Blazor.Universal](https://github.com/pushqrdx/Blazor.Universal) - Example of using Blazor to build Xamarin based UWP application without WebAssembly.
 * [BlazorUnmarshalledCanvas](https://github.com/jhwcn/BlazorUnmarshalledCanvas) - Unmarshalled invoking of Canvas 2d context from Blazor.
 * [BlazorValidationControls](https://github.com/hishamco/BlazorValidationControls) - Blazor validation controls.
-* [Blazor Wake-on-LAN](https://github.com/georg-jung/BlazorWoL) - ![Last commit](https://img.shields.io/github/last-commit/georg-jung/BlazorWoL?style=flat-square&cacheSeconds=86000) Simple Wake-on-LAN app for local networks. Blazor Server + EF Core + DI + CI.
 * [Blazor + Electron sample](https://github.com/aspnet/AspLabs/tree/master/src/ComponentsElectron) - Explore how a Blazor app can be used to build a cross-platform desktop app.
 * [Data Driven Layout](https://github.com/hutchcodes/Blazor.DataDrivenLayout) - Two ways of driving the layout based on data in the page.
 * [Pattern Maker](https://github.com/sapsari/website-blazor-demo) - C# code transformation demo that uses Roslyn and Monaco Editor. [Demo](https://patternmaker.netlify.com/).
@@ -169,6 +168,7 @@ Note: the Blazor Visual Studio extension is no longer required since .NET Core 3
 * [Blazor Tour of Heroes](https://github.com/georgemathieson/blazor-tour-of-heroes) - Blazor Tour of Heroes, using [Blazor-State](https://github.com/TimeWarpEngineering/blazor-state)(State Management architecture utilizing the MediatR pipeline) for the Redux style state.
 * [Blazor.Console](https://github.com/ardacetinkaya/Blazor.Console) - ![last commit](https://img.shields.io/github/last-commit/ardacetinkaya/Blazor.Console?style=flat-square&cacheSeconds=86000) A simple component to mock CLI for ASP.NET Core 3.0 Blazor applications to execute some custom commands for an application.
 * [Cognitive Services Explorer](https://github.com/jernejk/CognitiveServices.Explorer) - ![last commit](https://img.shields.io/github/last-commit/jernejk/CognitiveServices.Explorer?style=flat-square&cacheSeconds=86000) PWA enabled app used to showcase what Cognitive Services can do, built-in client-side Blazor. [Demo](https://jernejk.github.io/CognitiveServices.Explorer/).
+* [Blazor Wake-on-LAN](https://github.com/georg-jung/BlazorWoL) - ![Last commit](https://img.shields.io/github/last-commit/georg-jung/BlazorWoL?style=flat-square&cacheSeconds=86000) Wake-on-LAN app for local networks. Blazor Server + EF Core + DI + CI.
 
 ## Tutorials
 * [Blazor workshop](https://github.com/dotnet-presentations/blazor-workshop/) - ![GitHub stars](https://img.shields.io/github/stars/dotnet-presentations/blazor-workshop?style=flat-square&cacheSeconds=604800) Blazor app building workshop by [.NET Foundation](https://www.dotnetfoundation.org/), Blazzing Pizza.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Note: the Blazor Visual Studio extension is no longer required since .NET Core 3
 * [Blazor.Universal](https://github.com/pushqrdx/Blazor.Universal) - Example of using Blazor to build Xamarin based UWP application without WebAssembly.
 * [BlazorUnmarshalledCanvas](https://github.com/jhwcn/BlazorUnmarshalledCanvas) - Unmarshalled invoking of Canvas 2d context from Blazor.
 * [BlazorValidationControls](https://github.com/hishamco/BlazorValidationControls) - Blazor validation controls.
+* [Blazor Wake-on-LAN](https://github.com/georg-jung/BlazorWoL) - ![Last commit](https://img.shields.io/github/last-commit/georg-jung/BlazorWoL?style=flat-square&cacheSeconds=86000) Simple Wake-on-LAN app for local networks. Blazor Server + EF Core + DI + CI.
 * [Blazor + Electron sample](https://github.com/aspnet/AspLabs/tree/master/src/ComponentsElectron) - Explore how a Blazor app can be used to build a cross-platform desktop app.
 * [Data Driven Layout](https://github.com/hutchcodes/Blazor.DataDrivenLayout) - Two ways of driving the layout based on data in the page.
 * [Pattern Maker](https://github.com/sapsari/website-blazor-demo) - C# code transformation demo that uses Roslyn and Monaco Editor. [Demo](https://patternmaker.netlify.com/).


### PR DESCRIPTION
[Blazor Wake-on-LAN](https://github.com/georg-jung/BlazorWoL) is a small but full-fledged WoL app for local networks, written in server-side blazor. The intent is to be real-world usable on one hand and beeing an example for a simple blazor app on the other hand. To achieve this the scope is limited but the goal is to do things right. Many used techniques will be needed for most blazor projects and the corresponding code can be used as a template. MIT licensed.

* Server Side Blazor
* .Net Core 3.1
* DI with `Microsoft.Extensions.DependencyInjection`
* CI with Azure Pipelines
* EF Core Code First with Migrations

---

* Adding & deleting hosts (DB)
* Waking hosts via magic packet
* Detect online status of hosts using ping and scanning for open MS RDP port
* MAC detection via ARP