### PR TITLE
Added lazy loading for CSS style sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Note: the Blazor Visual Studio extension is no longer required since .NET Core 3
 * [Howler.Blazor](https://github.com/StefH/WebDAV-AudioPlayer/tree/master/src/Howler.Blazor) - A Blazor JSInterop wrapper for Howler.js, an audio library.
 * [DataJuggler.Blazor.FileUpload](https://github.com/DataJuggler/BlazorFileUpload) - Wrapper for Steve Sanderson's BlazorFileInput component.
 * [Cortex.Net](https://github.com/jspuij/Cortex.Net) - State management like MobX for .NET and Blazor.
+* [Blazor.LazyStyleSheet] (https://github.com/excubo-ag/Blazor.LazyStyleSheet) - Lazy loading for CSS style sheets.
 ### Others
 * [Blazor Extensions Home](https://github.com/BlazorExtensions/Home) - ![GitHub stars](https://img.shields.io/github/stars/BlazorExtensions/Home?style=flat-square&cacheSeconds=604800&logo=microsoft) Home for Blazor Extensions.
 * [Bolero](https://github.com/fsbolero/Bolero) - ![GitHub stars](https://img.shields.io/github/stars/fsbolero/Bolero?style=flat-square&cacheSeconds=604800) ![last commit](https://img.shields.io/github/last-commit/fsbolero/Bolero?style=flat-square&cacheSeconds=86400) Blazor for F# with hot reloaded templates, type-safe endpoints and routing, remoting, and much more.


### PR DESCRIPTION
A library that manages lazy loading for CSS style sheets. I've put this in the Tools & Utilities section as it does not have a UI component, only a helper component to render `<link>`-tags.