### PR TITLE
Fix .NET Frontend Day date

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contributions are always welcome! Please take a look at the [contribution guidel
 If you need to search on this list you can try this great website: [Awesome Blazor Browser](https://jsakamoto.github.io/awesome-blazor-browser/).
 Thanks @jsakamoto for this! [Source code](https://github.com/jsakamoto/awesome-blazor-browser) ![stars](https://img.shields.io/github/stars/jsakamoto/awesome-blazor-browser?style=flat-square&cacheSeconds=604800) ![last commit](https://img.shields.io/github/last-commit/jsakamoto/awesome-blazor-browser?style=flat-square&cacheSeconds=86400).
 
-## Event: ".NET Frontend Day" (January 8, 2021).
+## Event: ".NET Frontend Day" (January 28, 2021).
 [<img src="https://www.dotnet-frontend.com/logo.jpg" align="center" width="60%">](https://www.dotnet-frontend.com/)
 - A full day online, with focus on building frontend applications using .NET.
 - .NET Frontend Day is a community organized conference.


### PR DESCRIPTION
This pull request updates the date listed for .NET Frontend Day in the readme as the date currently listed is incorrect. The correct date was sourced from: https://www.dotnet-frontend.com/ 